### PR TITLE
don't print unprintable characters

### DIFF
--- a/vdu/index.html
+++ b/vdu/index.html
@@ -205,8 +205,8 @@ VDU 23,n,p7,P2,p5,p4,p5,p6,p7,p8
       if (isNaN(n)) {
         return;
       }
-      if (n==10) {out += '[WARN: 10 cannot be encoded]';}
-      if (n==13) {out += '[WARN: 13 cannot be encoded]';}
+      if (n==10) {out += '[WARN: 10 cannot be encoded]'; return;}
+      if (n==13) {out += '[WARN: 13 cannot be encoded]'; return;}
       if (n==34) {out += safeChar(n);} // escape "
       out += safeChar(n);
     }


### PR DESCRIPTION
Currently the unprintable characters 10 and 13 are still output to the string (so you get confusing extra characters with 10, and a spooky invisible carriage return with 13). This PR fixes that issue.

e.g. VDU 9,10,11 should output

`PRINT"ĉ[WARN: 10 cannot be encoded]ċ"
`and not
`PRINT"ĉ[WARN: 10 cannot be encoded]Ċċ"`

I find it worth fixing because I use this tool to encode data and encountered bugs when I just patched out the [WARN] parts with other numbers, due to extra characters still being present.